### PR TITLE
Features/refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ aws-smithy-types-convert = { version = "0.54.4", features = ["convert-chrono"] }
 chrono = "0.4.24"
 futures = "0.3.27"
 tabled = "0.10.0"
+clap = { version = "4.1.9", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@
 For cleaning up unused AWS load balancers. Supports ALBs, NLBs, Classic Load Balancers.
 
 # TODO
-1. Add `vpc_id` to Structs so we can add it as a filter for deletion. (Only delete if `vpc_id` is included in configuration).
-2. Refactor deletion. (Test if working).
+[/] Add `vpc_id` to Structs so we can add it as a filter for deletion. (Only delete if `vpc_id` is included in configuration).
+[/] Refactor deletion. (Test if working).

--- a/src/elb.rs
+++ b/src/elb.rs
@@ -7,17 +7,21 @@ use aws_sdk_cloudwatch::{
     Client as CloudWatchClient,
 };
 use aws_sdk_elasticloadbalancing::model::LoadBalancerDescription as LoadBalancer;
+use aws_sdk_elasticloadbalancing::output::DeleteLoadBalancerOutput as DeleteOutput;
 use aws_sdk_elasticloadbalancing::Client as ELBClient;
 use aws_types::region::Region;
+use std::collections::HashMap;
 use std::fmt;
 use std::sync::{Arc, Mutex};
 use tabled::Tabled;
+use tokio::sync::Semaphore;
 
 #[derive(Clone, Tabled)]
 pub struct ElbData {
     pub name: String,
     pub state: LoadBalancerState,
     pub region: Region,
+    pub vpc_id: String,
 }
 
 impl fmt::Debug for ElbData {
@@ -26,45 +30,58 @@ impl fmt::Debug for ElbData {
             .field("name", &self.name)
             .field("state", &self.state)
             .field("region", &self.region)
+            .field("vpc_id", &self.vpc_id)
             .finish()
     }
 }
 
 impl ElbData {
-    pub fn new(name: &str, state: LoadBalancerState, region: Region) -> Self {
+    pub fn new(name: &str, state: LoadBalancerState, region: Region, vpc_id: String) -> Self {
         ElbData {
             name: name.to_string(),
             state,
             region,
+            vpc_id,
         }
     }
 }
 
-pub async fn process_region(region: Region, days: i64, _delete_inactive: bool) -> Vec<ElbData> {
+pub async fn process_region(
+    region: Region,
+    days: i64,
+    vpc_ids: HashMap<String, bool>,
+) -> Vec<ElbData> {
     let config = aws_config::from_env().region(region).load().await;
     let elb_client = ELBClient::new(&config);
     let cw_client = CloudWatchClient::new(&config);
 
     let elb_lbs = get_elb_load_balancers(&elb_client).await;
     let elb_data: Arc<Mutex<Vec<ElbData>>> = Arc::new(Mutex::new(vec![]));
+    let sem = Arc::new(Semaphore::new(10));
 
     let mut tasks = Vec::new();
 
     for lb in elb_lbs {
         let cw_client = cw_client.clone();
-
         let lb_name = lb.load_balancer_name().unwrap().to_string();
+        let vpc_ids = vpc_ids.clone();
+        let vpc_id = lb.vpc_id().unwrap().to_string();
         let dns_name = lb.dns_name().unwrap().to_string();
+
         let region_string = utils::extract_region_from_elb_dns(&dns_name).unwrap();
         let region = Region::new(region_string);
         let elb_data = Arc::clone(&elb_data);
+        let sem = Arc::clone(&sem);
 
         let task = async move {
+            let _perm = sem.acquire_owned().await;
             println!("Processing ELB: {}", lb_name);
             let state = get_elb_lb_state(lb_name.to_string(), &cw_client, days).await;
             if let Some(state) = state {
                 let mut elb_data = elb_data.lock().unwrap();
-                elb_data.push(ElbData::new(lb_name.as_str(), state, region));
+                if vpc_ids.contains_key(vpc_id.as_str()) {
+                    elb_data.push(ElbData::new(lb_name.as_str(), state, region, vpc_id));
+                }
             }
         };
         tasks.push(task);
@@ -79,6 +96,39 @@ pub async fn process_region(region: Region, days: i64, _delete_inactive: bool) -
     let elb_data = elb_data.lock().unwrap();
 
     elb_data.to_vec()
+}
+
+pub async fn process_elb(elbs: Vec<ElbData>) -> Vec<DeleteOutput> {
+    let deletion_results: Arc<Mutex<Vec<DeleteOutput>>> = Arc::new(Mutex::new(vec![]));
+    let mut tasks = Vec::new();
+
+    for elb in elbs {
+        let region = elb.region;
+        let name = elb.name;
+
+        let config = aws_config::from_env().region(region).load().await;
+        let client = ELBClient::new(&config);
+
+        let deletion_results = Arc::clone(&deletion_results);
+
+        let task = async move {
+            println!("Processing ELB deletion: {}", name);
+            let res = delete_elb(&name, &client).await;
+            let mut deletion_results = deletion_results.lock().unwrap();
+            deletion_results.push(res);
+        };
+
+        tasks.push(task);
+    }
+
+    let mut futures = Vec::new();
+    for task in tasks {
+        futures.push(task);
+    }
+    futures::future::join_all(futures).await;
+
+    let deletion_results = deletion_results.lock().unwrap();
+    deletion_results.to_vec()
 }
 
 async fn get_elb_load_balancers(client: &ELBClient) -> Vec<LoadBalancer> {
@@ -136,12 +186,13 @@ async fn get_elb_lb_state(
     }
 }
 
-async fn _delete_elb_lb(name: &str, client: &ELBClient) {
-    client
+async fn delete_elb(name: &str, client: &ELBClient) -> DeleteOutput {
+    let out = client
         .delete_load_balancer()
         .load_balancer_name(name)
         .send()
         .await
         .unwrap();
     println!("Deleted Classic Load Balancer: {:?}", name);
+    out
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,4 +1,41 @@
 use std::fmt;
+use std::str::FromStr;
+
+#[derive(Clone, PartialEq)]
+pub enum RunOption {
+    List,
+    Delete,
+}
+
+impl fmt::Debug for RunOption {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            RunOption::List => write!(f, "List"),
+            RunOption::Delete => write!(f, "Delete"),
+        }
+    }
+}
+
+impl fmt::Display for RunOption {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            RunOption::List => write!(f, "List"),
+            RunOption::Delete => write!(f, "Delete"),
+        }
+    }
+}
+
+impl FromStr for RunOption {
+    type Err = ();
+
+    fn from_str(input: &str) -> Result<RunOption, Self::Err> {
+        match input.to_lowercase().as_str() {
+            "list" => Ok(RunOption::List),
+            "delete" => Ok(RunOption::Delete),
+            _ => Err(()),
+        }
+    }
+}
 
 #[derive(Clone, PartialEq)]
 pub enum LoadBalancerState {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,37 @@
+use crate::models::RunOption;
+use aws_types::region::Region;
+use std::collections::HashMap;
+use std::str::FromStr;
+
+pub fn parse_regions_arg(regions: &str) -> Vec<Region> {
+    let regions = regions.split(",");
+    let mut regions_obj: Vec<Region> = Vec::new();
+
+    for region in regions {
+        regions_obj.push(Region::new(region.to_string()));
+    }
+
+    regions_obj
+}
+
+pub fn parse_vpc_ids_arg(vpc_ids: &str) -> HashMap<String, bool> {
+    let vpc_ids = vpc_ids.split(",");
+    let mut vpc_ids_map: HashMap<String, bool> = HashMap::new();
+
+    for vpc_id in vpc_ids {
+        vpc_ids_map.insert(vpc_id.to_string(), true);
+    }
+
+    vpc_ids_map
+}
+
+pub fn parse_run_option_arg(run_option: &str) -> RunOption {
+    match RunOption::from_str(run_option) {
+        Ok(val) => val,
+        Err(_) => panic!("Shouldn't happen!"),
+    }
+}
+
 pub fn extract_id_from_lb_arn(arn: &str) -> Option<String> {
     let parts: Vec<&str> = arn.split(':').collect();
     if parts.len() >= 6 {


### PR DESCRIPTION
- Adds vpc_id to ElbV2Data and ElbData. To be used as a filter pass for when listing/deleting inactive load balancers.
- Adds CLI args.
- Refactor(s)